### PR TITLE
Gradle refactoring continued

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[{*.kt, *.kts}]
+indent_size = 4
+indent_style = space

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.changelog.date
 
 plugins {
-    `java-gradle-plugin`
+    `kotlin-dsl`
     `maven-publish`
     kotlin("jvm") version "1.6.21"
     id("org.jetbrains.kotlinx.kover") version "0.5.1"

--- a/src/main/kotlin/com/pswidersk/gradle/python/ListPropertiesTask.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/python/ListPropertiesTask.kt
@@ -1,12 +1,12 @@
 package com.pswidersk.gradle.python
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskAction
 
 abstract class ListPropertiesTask : DefaultTask() {
 
-    @Internal
+    @get:Nested
     val pythonPluginExtension: PythonPluginExtension = project.pythonPlugin
 
     init {

--- a/src/main/kotlin/com/pswidersk/gradle/python/MinicondaSetupTask.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/python/MinicondaSetupTask.kt
@@ -1,19 +1,19 @@
 package com.pswidersk.gradle.python
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import org.gradle.process.ExecResult
 import java.io.File
 import java.net.URL
 import javax.inject.Inject
+import org.gradle.api.tasks.Nested
 
 abstract class MinicondaSetupTask @Inject constructor(
     private val execOperations: ExecOperations,
 ) : DefaultTask() {
 
-    @Internal
+    @get:Nested
     val pythonPluginExtension: PythonPluginExtension = project.pythonPlugin
 
     init {
@@ -34,7 +34,7 @@ abstract class MinicondaSetupTask @Inject constructor(
         allowInstallerExecution(minicondaInstaller)
         logger.lifecycle("Installing $DEFAULT_MINICONDA_RELEASE...")
         execOperations.exec {
-            it.executable = minicondaInstaller.absolutePath
+            executable = minicondaInstaller.absolutePath
             val execArgs = if (isWindows)
                 listOf(
                     "/InstallationType=JustMe",
@@ -45,7 +45,7 @@ abstract class MinicondaSetupTask @Inject constructor(
                 )
             else
                 listOf("-b", "-u", "-p", minicondaDirFile.absolutePath)
-            it.args(execArgs)
+            args(execArgs)
         }
     }
 
@@ -53,8 +53,8 @@ abstract class MinicondaSetupTask @Inject constructor(
         if (!isWindows) {
             logger.lifecycle("Allowing user to run installer...")
             execOperations.exec {
-                it.executable = "chmod"
-                it.args("u+x", minicondaInstaller.absolutePath)
+                executable = "chmod"
+                args("u+x", minicondaInstaller.absolutePath)
             }
         }
     }

--- a/src/main/kotlin/com/pswidersk/gradle/python/PythonPlugin.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/python/PythonPlugin.kt
@@ -2,15 +2,22 @@ package com.pswidersk.gradle.python
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.*
 
 class PythonPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = with(project) {
-        extensions.create(PYTHON_PLUGIN_EXTENSION_NAME, PythonPluginExtension::class.java)
+        val extension = extensions.create<PythonPluginExtension>(PYTHON_PLUGIN_EXTENSION_NAME)
         tasks.register<ListPropertiesTask>("listPluginProperties") { }
-        val minicondaSetupTask = tasks.register<MinicondaSetupTask>("minicondaSetup") { }
+        val minicondaSetupTask = tasks.register<MinicondaSetupTask>("minicondaSetup")
         tasks.register<EnvSetupTask>("envSetup") {
-            it.dependsOn(minicondaSetupTask)
+            dependsOn(minicondaSetupTask)
+        }
+        tasks.withType<EnvSetupTask>().configureEach {
+            condaExec.convention(extension.condaExec)
+            pythonEnvName.convention(extension.pythonEnvName)
+            pythonVersion.convention(extension.pythonVersion)
+            pythonEnvDir.convention(extension.pythonEnvDir)
         }
     }
 

--- a/src/main/kotlin/com/pswidersk/gradle/python/PythonPluginExtension.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/python/PythonPluginExtension.kt
@@ -1,67 +1,72 @@
 package com.pswidersk.gradle.python
 
+import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.internal.file.FileFactory
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.Input
 import org.gradle.internal.os.OperatingSystem
-import javax.inject.Inject
+import org.gradle.kotlin.dsl.property
 
 abstract class PythonPluginExtension @Inject constructor(
-    providerFactory: ProviderFactory,
     project: Project,
     objects: ObjectFactory,
-    fileFactory: FileFactory
 ) {
 
-    val pythonVersion: Property<String> = objects.property<String>().convention(DEFAULT_PYTHON_VERSION)
+    @get:Input
+    val pythonVersion: Property<String> =
+        objects.property<String>().convention(DEFAULT_PYTHON_VERSION)
 
-    val minicondaVersion: Property<String> = objects.property<String>().convention(DEFAULT_MINICONDA_VERSION)
+    @get:Input
+    val minicondaVersion: Property<String> =
+        objects.property<String>().convention(DEFAULT_MINICONDA_VERSION)
 
+    @get:Input
     val installDir: DirectoryProperty = objects.directoryProperty().convention(
-        providerFactory.provider {
-            fileFactory.dir(project.rootDir).dir(GRADLE_FILES_DIR).dir(PYTHON_ENVS_DIR)
-        }
+        project.layout.projectDirectory.dir(GRADLE_FILES_DIR).dir(PYTHON_ENVS_DIR)
     )
 
+    @get:Input
     internal val minicondaDir: DirectoryProperty = objects.directoryProperty().convention(
-        providerFactory.provider {
-            installDir.get()
-                .dir(os)
-                .dir("$DEFAULT_MINICONDA_RELEASE-${minicondaVersion.get()}")
+        installDir.zip(minicondaVersion) { dir, version ->
+            dir.dir(os).dir("$DEFAULT_MINICONDA_RELEASE-${version}")
         }
     )
 
+    @get:Input
     internal val pythonEnvName: Property<String> = objects.property<String>().convention(
-        providerFactory.provider { "python-${pythonVersion.get()}" }
+        pythonVersion.map { ver -> "python-${ver}" }
     )
 
+    @get:Input
     internal val pythonEnvDir: DirectoryProperty = objects.directoryProperty().convention(
-        providerFactory.provider { minicondaDir.get().dir("envs").dir(pythonEnvName.get()) }
-    )
-
-    internal val condaBinDir: DirectoryProperty = objects.directoryProperty().convention(
-        providerFactory.provider { minicondaDir.get().dir("condabin") }
-    )
-
-    internal val condaActivatePath: RegularFileProperty = objects.fileProperty().convention(
-        providerFactory.provider {
-            if (OperatingSystem.current().isWindows)
-                condaBinDir.get().file("activate.bat")
-            else
-                minicondaDir.get().dir("bin").file("activate")
+        minicondaDir.zip(pythonVersion) { dir, env ->
+            dir.dir("envs").dir(env)
         }
     )
 
+    @get:Input
+    internal val condaBinDir: DirectoryProperty = objects.directoryProperty().convention(
+        minicondaDir.dir("condabin")
+    )
+
+    @get:Input
+    internal val condaActivatePath: RegularFileProperty = objects.fileProperty().convention(
+        if (OperatingSystem.current().isWindows)
+            condaBinDir.file("activate.bat")
+        else
+            minicondaDir.file("bin/activate")
+    )
+
+    @get:Input
     internal val condaExec: RegularFileProperty = objects.fileProperty().convention(
-        providerFactory.provider {
+        condaBinDir.map { dir ->
             if (OperatingSystem.current().isWindows)
-                this.condaBinDir.get().file("conda.bat")
+                dir.file("conda.bat")
             else
-                this.condaBinDir.get().file("conda")
+                dir.file("conda")
         }
     )
 }

--- a/src/main/kotlin/com/pswidersk/gradle/python/PythonPluginUtils.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/python/PythonPluginUtils.kt
@@ -1,43 +1,15 @@
 package com.pswidersk.gradle.python
 
-import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.Task
-import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.kotlin.dsl.getByType
 
-
-/**
- * Creates a [Property] to hold values of the given type.
- *
- * @param T the type of the property
- * @return the property
- */
-internal inline fun <reified T : Any> ObjectFactory.property(): Property<T> =
-    property(T::class.javaObjectType)
-
-/**
- * Registers a [Task].
- *
- * @param T the type of the task
- * @param name task name
- * @param configurationAction config block
- * @return task
- */
-internal inline fun <reified T : Task> TaskContainer.register(
-    name: String,
-    configurationAction: Action<T>
-): TaskProvider<T> =
-    register(name, T::class.javaObjectType, configurationAction)
 
 /**
  * Gets the [PythonPluginExtension] that is installed on the project.
  */
 internal val Project.pythonPlugin: PythonPluginExtension
-    get() = extensions.getByType(PythonPluginExtension::class.java)
+    get() = extensions.getByType()
 
 /**
  * Returns if operating system is Windows

--- a/src/test/kotlin/com/pswidersk/gradle/python/PythonPluginTest.kt
+++ b/src/test/kotlin/com/pswidersk/gradle/python/PythonPluginTest.kt
@@ -156,7 +156,7 @@ internal class PythonPluginTest {
         }
         with(secondRunResult) {
             assertThat(task(":minicondaSetup")!!.outcome).isEqualTo(TaskOutcome.SKIPPED)
-            assertThat(task(":envSetup")!!.outcome).isEqualTo(TaskOutcome.SKIPPED)
+            assertThat(task(":envSetup")!!.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
             assertThat(task(":runTestScript")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
             assertThat(output).contains(pythonMessage)
         }


### PR DESCRIPTION
Hi! Here's some further work to show what else might be done.

I think for now it's more than good enough. It can always be improved incrementally later. I'll leave some notes in this PR and the other one - it helps me to explain if there's code I can demo.

Any questions, let me know!

---

- add .editorconfig (simple formatting helper)
- update to use kotlin-dsl (better alignment with gradle.kts DSL)
- replace helpers in PythonPluginUtils.kt with `import org.gradle.kotlin.dsl`
- try to tidy up provider convention setup in Extension
- register specific inputs for EnvSetupTask (better task work avoidance)
- replace InputStream/OutputStream with string getters (I'm taking a guess that setting streams isn't needed, but reading output might be used internally)