### PR TITLE
fix: Fixed `.idea` directory file locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.kotlin
 build
 
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-### Added
-
 ### Changed
 
-### Removed
+- Fixed `.idea` directory file locking.
+- Updated Kotlin to `2.0.0` and other dependencies.
+- Default Miniconda version to `py312_24.5.0-0`.
+- Default Python version to `3.12.4`.
 
 ## 2.7.1 - 2024-04-28
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,3 +74,13 @@ publishing {
 changelog {
     groups = listOf("Added", "Changed", "Removed")
 }
+
+kover {
+    reports {
+        total {
+            xml {
+                onCheck = true
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,13 +2,13 @@
 # libraries
 commonsIO = "2.16.1"
 snakeyaml = "2.2"
-junit = "5.10.2"
-assertj = "3.25.3"
-wiremock = "3.5.3"
+junit = "5.10.3"
+assertj = "3.26.0"
+wiremock = "3.8.0"
 
 # plugins
-kotlin = "1.9.23"
-kover = "0.7.6"
+kotlin = "2.0.0"
+kover = "0.8.2"
 pluginPublish = "1.2.1"
 changelog = "2.2.0"
 

--- a/src/main/kotlin/com/pswidersk/gradle/python/PythonPluginConstants.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/python/PythonPluginConstants.kt
@@ -23,9 +23,9 @@ const val PYTHON_ENVS_DIR = "python"
 const val PLUGIN_TASKS_GROUP_NAME = "python"
 
 /**
- * Default Python version.
+ * Default Python version. [List of available releases](https://anaconda.org/conda-forge/python/).
  */
-const val DEFAULT_PYTHON_VERSION = "3.10.12"
+const val DEFAULT_PYTHON_VERSION = "3.12.4"
 
 /**
  * Default Conda installer.
@@ -33,9 +33,9 @@ const val DEFAULT_PYTHON_VERSION = "3.10.12"
 const val DEFAULT_CONDA_INSTALLER = "Miniconda3"
 
 /**
- * Default Conda version.
+ * Default Conda version. [List of available releases](https://repo.anaconda.com/miniconda).
  */
-const val DEFAULT_CONDA_VERSION = "py311_23.5.2-0"
+const val DEFAULT_CONDA_VERSION = "py312_24.5.0-0"
 
 /**
  * Default Conda repository URL.

--- a/src/main/kotlin/com/pswidersk/gradle/python/sdkimport/SdkImportUtils.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/python/sdkimport/SdkImportUtils.kt
@@ -41,14 +41,18 @@ private fun entryMatches(
     moduleName: String
 ) = entry.module == moduleName && entry.type == PYTHON_SDK_TYPE
 
-internal fun File.loadAsYamlImportConfig(): SdkImportConfig =
+internal fun File.loadAsYamlImportConfig(): SdkImportConfig = this.inputStream().use {
     Yaml(Constructor(SdkImportConfig::class.java, LoaderOptions()))
-        .load(this.inputStream()) ?: SdkImportConfig()
+        .load(it) ?: SdkImportConfig()
+}
+
 
 internal fun SdkImportConfig.saveAsYamlFile(file: File) {
     val dumperOptions = DumperOptions()
     dumperOptions.defaultFlowStyle = BLOCK
     val representer = Representer(dumperOptions)
     representer.addClassTag(SdkImportConfig::class.java, MAP)
-    Yaml(representer, dumperOptions).dump(this, file.writer())
+    file.writer().use {
+        Yaml(representer, dumperOptions).dump(this, it)
+    }
 }

--- a/src/test/kotlin/com/pswidersk/gradle/python/ListPropertiesTest.kt
+++ b/src/test/kotlin/com/pswidersk/gradle/python/ListPropertiesTest.kt
@@ -37,7 +37,7 @@ class ListPropertiesTest {
             assertThat(task(":listPluginProperties")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
             assertThat(output).contains(
                 "Install directory: $defaultWorkingDir",
-                "Miniconda3 version: py311_23.5.2-0",
+                "Miniconda3 version: py312_24.5.0-0",
                 "Conda repo URL: https://repo.anaconda.com/miniconda"
             )
         }

--- a/src/test/kotlin/com/pswidersk/gradle/python/PythonPluginTest.kt
+++ b/src/test/kotlin/com/pswidersk/gradle/python/PythonPluginTest.kt
@@ -13,9 +13,6 @@ import java.io.File
 
 internal class PythonPluginTest {
 
-    @TempDir
-    lateinit var tempDir: File
-
     @Test
     fun `test if plugin was applied`() {
         val project: Project = ProjectBuilder.builder().build()
@@ -25,9 +22,10 @@ internal class PythonPluginTest {
     }
 
     @Test
-    fun `test if test python script was run successfully`() {
+    fun `test if test python script was run successfully`(@TempDir tempDir: File) {
         // given
-        tempDir.resolve(".idea").mkdir()
+        val ideaDir = tempDir.resolve(".idea")
+        ideaDir.mkdir()
         val pythonMessage = "Hello world from Gradle Python Plugin :)"
         val buildFile = File(tempDir, "build.gradle.kts")
         val testScriptFile = File(tempDir, "testScript.py")
@@ -78,6 +76,6 @@ internal class PythonPluginTest {
             assertThat(task(":runTestScript")!!.outcome).isEqualTo(TaskOutcome.SUCCESS)
             assertThat(output).contains(pythonMessage)
         }
-        assertThat(tempDir.resolve(".idea/sdk-import.yml")).exists()
+        assertThat(ideaDir.resolve("sdk-import.yml")).exists()
     }
 }


### PR DESCRIPTION
- Fixed `.idea` directory file locking.
- Updated Kotlin to `2.0.0` and other dependencies.
- Default Miniconda version to `py312_24.5.0-0`.
- Default Python version to `3.12.4`.