### PR TITLE
Improve architecture name mapping

### DIFF
--- a/src/main/kotlin/com/pswidersk/gradle/python/PythonPluginUtils.kt
+++ b/src/main/kotlin/com/pswidersk/gradle/python/PythonPluginUtils.kt
@@ -37,16 +37,22 @@ internal val arch: String
         val arch = System.getProperty("os.arch")
         return when {
             OperatingSystem.current().isMacOsX -> when (arch) {
+                "amd64" -> "x86_64"
                 "aarch64" -> "arm64"
                 else -> arch
             }
 
             isWindows -> when (arch) {
                 "amd64" -> "x86_64"
+                "aarch64" -> "x86_64" // no aarch64/arm64 installer available for windows
                 else -> arch
             }
 
-            else -> "x86_64"
+            else -> when (arch) {
+                "aarch64" -> "aarch64"
+                "amd64" -> "x86_64"
+                else -> arch
+            }
         }
     }
 


### PR DESCRIPTION
Improve os-specific mapping of java system architecture names to conda system architecture names. Makes windows use the x86_64 binary for aarch64 systems (since there is no dedicated conda version). Makes linux use the aarch64 binary for the corresponding systems.
A correct mapping by default is important to make projects run across different operating systems / system architectures, i.e. in contexts, where that information cannot be hard coded in the build scripts.